### PR TITLE
Update 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,14 @@ test:
 
 about:
   home: https://github.com/pypa/build
+  summary: A simple, correct PEP517 package builder
+  description: |
+    build manages pyproject.toml-based builds, invoking build-backend hooks 
+    as appropriate to build a distribution package. It is a simple build tool 
+    and does not perform any dependency management.
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: A simple, correct PEP517 package builder
   dev_url: https://github.com/pypa/build
   doc_url: https://pypa-build.readthedocs.io/en/stable/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - python-build --help 
   requires:
     - pip
-    - python <3.10
+    - python
 
 about:
   home: https://github.com/pypa/build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - flit-core
   run:
     - python
-    - colorama
+    - colorama  # [win]
     - packaging >=19.0
     - pyproject_hooks
     - importlib-metadata >=0.22  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ test:
     - python-build --help 
   requires:
     - pip
-    - python
 
 about:
   home: https://github.com/pypa/build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,10 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
-  noarch: python
+  skip: True  # [py<37]
   entry_points:
     - python-build = build.__main__:entrypoint
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,9 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=40.8.0
+    - setuptools
     - wheel
+    - flit-core
   run:
     - python >3.6
     - importlib-metadata >=0.22  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - flit-core
   run:
     - python
+    - colorama
     - packaging >=19.0
     - pyproject_hooks
     - importlib-metadata >=0.22  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-build" %}
-{% set version = "0.7.0" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/build/build-{{ version }}.tar.gz
-  sha256: 1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f
+  sha256: d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - wheel
     - flit-core
   run:
-    - python >3.6
-    - importlib-metadata >=0.22  # [py<38]
+    - python
     - packaging >=19.0
-    - pep517 >=0.9.1
-    - toml
+    - pyproject_hooks
+    - importlib-metadata >=0.22  # [py<38]
+    - tomli >=1.1.0  # [py<311]
 
 test:
   imports:


### PR DESCRIPTION
[Upstream](https://github.com/pypa/build)
[Changelog](https://pypa-build.readthedocs.io/en/latest/changelog.html)

### Actions
- Updated version number and sha256
- Updated Python version skip
- Remove noarch
- Update dependencies
- Linter fixes