### PR TITLE
Rebuild against python 3.14 and add testing

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<39]
   entry_points:
     - python-build = build.__main__:entrypoint
@@ -33,12 +33,31 @@ requirements:
 test:
   imports:
     - build
+  source_files:
+    - tests
+    # Following files are required for some tests
+    - pyproject.toml
+    - src
+    - README.md
+    - LICENSE
   commands:
     - pip check
     - python-build --help
     - pyproject-build --help
+    # 'test_output' is flaky
+    # 'test_build_sdist' requires all files to be accessible from repo
+    - pytest -vv tests -k "not test_output and not test_build_sdist"
   requires:
     - pip
+    - flaky
+    - pytest >=6.2.4
+    - pytest-mock >=2
+    - filelock >=3
+    - wheel >=0.36.0
+    - setuptools >= 42.0.0 # [py<310]
+    - setuptools >= 56.0.0 # [py310]
+    - setuptools >= 56.0.0 # [py311]
+    - setuptools >= 67.8.0 # [py>=312]
 
 about:
   home: https://build.pypa.io/


### PR DESCRIPTION
python-build 1.3.0

**Destination channel:** defaults

### Links

- [PKG-10372](https://anaconda.atlassian.net/browse/PKG-10372)
- [Upstream repository](https://github.com/pypa/build/tree/1.3.0)

### Explanation of changes:

- rebuild against python 3.14 
- add testing


[PKG-10372]: https://anaconda.atlassian.net/browse/PKG-10372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ